### PR TITLE
feat: add JSONL support alongside SQLite

### DIFF
--- a/src/bd/jsonl-parser.ts
+++ b/src/bd/jsonl-parser.ts
@@ -1,0 +1,197 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import type { Issue, BeadsData } from '../types';
+
+/**
+ * Raw JSONL issue structure
+ */
+type JsonlIssue = {
+  id: string;
+  title: string;
+  description: string;
+  design?: string;
+  acceptance_criteria?: string;
+  notes?: string;
+  status: 'open' | 'in_progress' | 'blocked' | 'closed';
+  priority: number;
+  issue_type: 'bug' | 'feature' | 'task' | 'epic' | 'chore';
+  assignee?: string;
+  estimated_minutes?: number;
+  created_at: string;
+  updated_at: string;
+  closed_at?: string;
+  close_reason?: string;
+  external_ref?: string;
+  labels?: string[];
+  dependencies?: Array<{
+    issue_id: string;
+    depends_on_id: string;
+    type: 'blocks' | 'related' | 'parent-child' | 'discovered-from';
+    created_at: string;
+    created_by: string;
+  }>;
+  comments?: Array<{
+    id: number;
+    issue_id: string;
+    author: string;
+    text: string;
+    created_at: string;
+  }>;
+};
+
+type Dependency = {
+  issue_id: string;
+  depends_on_id: string;
+  type: string;
+};
+
+/**
+ * Read all issues from JSONL file
+ */
+export function loadBeadsFromJsonl(beadsPath: string = '.beads'): BeadsData {
+  const jsonlPath = join(beadsPath, 'issues.jsonl');
+
+  try {
+    // Read the entire file
+    const content = readFileSync(jsonlPath, 'utf-8');
+    const lines = content.split('\n');
+
+    const issues: Issue[] = [];
+    const byId = new Map<string, Issue>();
+    const dependencies: Dependency[] = [];
+
+    // Parse each line as JSON
+    for (let lineNum = 0; lineNum < lines.length; lineNum++) {
+      const line = lines[lineNum].trim();
+      if (!line) continue; // Skip empty lines
+
+      try {
+        const jsonlIssue = JSON.parse(line) as JsonlIssue;
+
+        // Convert JSONL issue to Issue type
+        const issue: Issue = {
+          id: jsonlIssue.id,
+          title: jsonlIssue.title,
+          description: jsonlIssue.description,
+          status: jsonlIssue.status,
+          priority: jsonlIssue.priority,
+          issue_type: jsonlIssue.issue_type,
+          assignee: jsonlIssue.assignee || null,
+          labels: jsonlIssue.labels || [],
+          created_at: jsonlIssue.created_at,
+          updated_at: jsonlIssue.updated_at,
+          closed_at: jsonlIssue.closed_at || null,
+        };
+
+        issues.push(issue);
+        byId.set(issue.id, issue);
+
+        // Collect dependencies for later processing
+        if (jsonlIssue.dependencies) {
+          for (const dep of jsonlIssue.dependencies) {
+            dependencies.push({
+              issue_id: dep.issue_id,
+              depends_on_id: dep.depends_on_id,
+              type: dep.type,
+            });
+          }
+        }
+      } catch (parseError) {
+        console.error(`Error parsing line ${lineNum + 1}:`, parseError);
+        continue;
+      }
+    }
+
+    // Sort by priority desc, created_at desc (matching SQLite parser)
+    issues.sort((a, b) => {
+      if (b.priority !== a.priority) {
+        return b.priority - a.priority;
+      }
+      return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    });
+
+    // Build dependency relationships (same logic as SQLite parser)
+    for (const dep of dependencies) {
+      const issue = byId.get(dep.issue_id);
+      if (!issue) continue;
+
+      if (dep.type === 'parent-child') {
+        // depends_on_id is the parent
+        issue.parent = dep.depends_on_id;
+
+        // Add to parent's children
+        const parent = byId.get(dep.depends_on_id);
+        if (parent) {
+          if (!parent.children) parent.children = [];
+          parent.children.push(dep.issue_id);
+        }
+      } else if (dep.type === 'blocks') {
+        // This issue is blocked by depends_on_id
+        if (!issue.blockedBy) issue.blockedBy = [];
+        issue.blockedBy.push(dep.depends_on_id);
+
+        // Add to blocker's blocks list
+        const blocker = byId.get(dep.depends_on_id);
+        if (blocker) {
+          if (!blocker.blocks) blocker.blocks = [];
+          blocker.blocks.push(dep.issue_id);
+        }
+      }
+    }
+
+    // Group by status
+    const byStatus: Record<string, Issue[]> = {
+      'open': [],
+      'closed': [],
+      'in_progress': [],
+      'blocked': [],
+    };
+
+    const stats = {
+      total: issues.length,
+      open: 0,
+      closed: 0,
+      blocked: 0,
+    };
+
+    for (const issue of issues) {
+      // Filter blockedBy to only include non-closed blockers
+      if (issue.blockedBy) {
+        issue.blockedBy = issue.blockedBy.filter(blockerId => {
+          const blocker = byId.get(blockerId);
+          return blocker && blocker.status !== 'closed';
+        });
+      }
+
+      // Auto-move issues with active blockers to 'blocked' status
+      const isBlocked = issue.blockedBy && issue.blockedBy.length > 0;
+      const actualStatus = isBlocked && issue.status === 'open' ? 'blocked' : issue.status;
+
+      if (byStatus[actualStatus]) {
+        byStatus[actualStatus].push(issue);
+      }
+
+      // Update stats
+      if (actualStatus === 'open') stats.open++;
+      else if (actualStatus === 'closed') stats.closed++;
+      else if (actualStatus === 'blocked') stats.blocked++;
+    }
+
+    return {
+      issues,
+      byStatus,
+      byId,
+      stats,
+      dataSource: 'jsonl' as const,
+    };
+  } catch (error) {
+    console.error('Error loading beads from JSONL:', error);
+    return {
+      issues: [],
+      byStatus: { 'open': [], 'closed': [], 'in_progress': [], 'blocked': [] },
+      byId: new Map(),
+      stats: { total: 0, open: 0, closed: 0, blocked: 0 },
+      dataSource: 'jsonl' as const,
+    };
+  }
+}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -289,9 +289,11 @@ export function App() {
       <Box flexDirection="column" padding={1}>
         <Text color={theme.colors.error} bold>Error:</Text>
         <Text color={theme.colors.error}>{error}</Text>
-        <Text color={theme.colors.textDim} marginTop={1}>
+        <Box marginTop={1}>
+          <Text color={theme.colors.textDim}>
           Make sure you're in a directory with a .beads/ folder
-        </Text>
+          </Text>
+        </Box>
       </Box>
     );
   }

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -190,8 +190,8 @@ function KanbanView() {
       {showExportDialog && selectedIssue && (
         <Box
           position="absolute"
-          top={Math.floor(terminalHeight / 2) - 10}
-          left={Math.floor(terminalWidth / 2) - 35}
+          marginTop={Math.floor(terminalHeight / 2) - 10}
+          marginLeft={Math.floor(terminalWidth / 2) - 35}
         >
           <ExportDialog
             issue={selectedIssue}
@@ -204,8 +204,8 @@ function KanbanView() {
       {showThemeSelector && (
         <Box
           position="absolute"
-          top={Math.floor(terminalHeight / 2) - 10}
-          left={Math.floor(terminalWidth / 2) - 30}
+          marginTop={Math.floor(terminalHeight / 2) - 10}
+          marginLeft={Math.floor(terminalWidth / 2) - 30}
         >
           <ThemeSelector onClose={toggleThemeSelector} />
         </Box>
@@ -252,9 +252,11 @@ export function Board() {
         <Text color={theme.colors.textDim}>
           Current width: {terminalWidth} columns
         </Text>
-        <Text color={theme.colors.textDim} marginTop={1}>
+        <Box marginTop={1}>
+          <Text color={theme.colors.textDim}>
           Please resize your terminal window.
-        </Text>
+          </Text>
+        </Box>
       </Box>
     );
   }

--- a/src/components/CommandBar.tsx
+++ b/src/components/CommandBar.tsx
@@ -112,7 +112,7 @@ export function CommandBar() {
           return { success: false, message: 'No issue selected' };
         }
         const statusArg = args[0];
-        const statusMap: Record<string, string> = {
+        const statusMap: Record<string, 'open' | 'closed' | 'in_progress' | 'blocked'> = {
           'o': 'open', 'open': 'open',
           'i': 'in_progress', 'in_progress': 'in_progress', 'ip': 'in_progress',
           'b': 'blocked', 'blocked': 'blocked',
@@ -121,7 +121,7 @@ export function CommandBar() {
         const newStatus = statusMap[statusArg];
         if (newStatus) {
           try {
-            await updateIssue(selectedIssue.id, { status: newStatus });
+            await updateIssue({ id: selectedIssue.id, status: newStatus });
             if (reloadCallback) reloadCallback();
             return { success: true, message: `Status → ${newStatus}` };
           } catch (e) {
@@ -139,7 +139,7 @@ export function CommandBar() {
         const prioArg = parseInt(args[0], 10);
         if (!isNaN(prioArg) && prioArg >= 0 && prioArg <= 4) {
           try {
-            await updateIssue(selectedIssue.id, { priority: prioArg });
+            await updateIssue({ id: selectedIssue.id, priority: prioArg });
             if (reloadCallback) reloadCallback();
             return { success: true, message: `Priority → P${prioArg}` };
           } catch (e) {

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -32,9 +32,9 @@ export function ConfirmDialog() {
 
   return (
     <Box
-      position="absolute"
-      top={Math.floor(terminalHeight / 2) - 4}
-      left={Math.floor(terminalWidth / 2) - 25}
+      position="relative"
+      marginTop={Math.floor(terminalHeight / 2) - 4}
+      marginLeft={Math.floor(terminalWidth / 2) - 25}
       flexDirection="column"
       borderStyle="double"
       borderColor={theme.colors.warning}

--- a/src/components/DependencyGraph.tsx
+++ b/src/components/DependencyGraph.tsx
@@ -81,7 +81,7 @@ export function DependencyGraph({ data, terminalWidth, terminalHeight }: Depende
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [scrollOffset, setScrollOffset] = useState(0);
   const [showDetails, setShowDetails] = useState(false);
-  const toggleEditForm = useBeadsStore(state => state.toggleEditForm);
+  const navigateToEditIssue = useBeadsStore(state => state.navigateToEditIssue);
 
   const levels = useMemo(() => buildDependencyLevels(data), [data]);
   const flatNodes = useMemo(() => levels.flat(), [levels]);
@@ -121,7 +121,7 @@ export function DependencyGraph({ data, terminalWidth, terminalHeight }: Depende
 
     // Edit selected issue
     if (input === 'e') {
-      toggleEditForm();
+      navigateToEditIssue();
     }
   });
 

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -27,10 +27,6 @@ export function Toast() {
 
   return (
     <Box
-      position="absolute"
-      top={0}
-      left={0}
-      right={0}
       justifyContent="center"
       paddingX={1}
     >

--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -102,7 +102,7 @@ export function TreeView({ data, terminalHeight }: TreeViewProps) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [scrollOffset, setScrollOffset] = useState(0);
   const [showDetails, setShowDetails] = useState(false);
-  const toggleEditForm = useBeadsStore(state => state.toggleEditForm);
+  const navigateToEditIssue = useBeadsStore(state => state.navigateToEditIssue);
 
   const tree = useMemo(() => buildTree(data), [data]);
   const flatNodes = useMemo(() => flattenTree(tree), [tree]);
@@ -142,7 +142,7 @@ export function TreeView({ data, terminalHeight }: TreeViewProps) {
 
     // Edit selected issue
     if (input === 'e') {
-      toggleEditForm();
+      navigateToEditIssue();
     }
   });
 

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -142,6 +142,7 @@ export const useBeadsStore = create<BeadsStore>((set, get) => ({
       closed: 0,
       blocked: 0,
     },
+    dataSource: 'sqlite' as const,
   },
 
   previousIssues: new Map(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,21 @@
+export type DataSource = 'sqlite' | 'jsonl';
+
+export type JsonlDependency = {
+  issue_id: string;
+  depends_on_id: string;
+  type: 'blocks' | 'related' | 'parent-child' | 'discovered-from';
+  created_at: string;
+  created_by: string;
+};
+
+export type JsonlComment = {
+  id: number;
+  issue_id: string;
+  author: string;
+  text: string;
+  created_at: string;
+};
+
 // Matches bd's actual SQLite schema
 export interface Issue {
   id: string;
@@ -17,6 +35,15 @@ export interface Issue {
   children?: string[];
   blockedBy?: string[];
   blocks?: string[];
+
+  // Optional JSONL fields
+  design?: string;
+  acceptance_criteria?: string;
+  notes?: string;
+  estimated_minutes?: number;
+  close_reason?: string;
+  external_ref?: string;
+  comments?: JsonlComment[];
 }
 
 export interface BeadsData {
@@ -29,4 +56,5 @@ export interface BeadsData {
     closed: number;
     blocked: number;
   };
+  dataSource: DataSource;
 }

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -50,13 +50,9 @@ export function showCompletionNotification(issue: Issue) {
   notifier.notify({
     title: '✅ Task Completed!',
     message: issue.title,
-    subtitle: `${issue.id} - Priority P${issue.priority}`,
-    sound: true, // macOS only
-    timeout: 5,
+    
     wait: false,
     icon, // Cross-platform icon support
-    contentImage: icon, // macOS specific for better display
-    appIcon: icon, // macOS app icon
   });
 }
 
@@ -69,13 +65,9 @@ export function showBlockedNotification(issue: Issue, blockedBy: string[]) {
   notifier.notify({
     title: '🚫 Task Blocked',
     message: issue.title,
-    subtitle: `Blocked by ${blockedBy.length} issue(s)`,
-    sound: false,
-    timeout: 5,
+    
     wait: false,
     icon, // Cross-platform icon support
-    contentImage: icon, // macOS specific for better display
-    appIcon: icon, // macOS app icon
   });
 }
 


### PR DESCRIPTION
## Summary

- Add support for reading issues from `.beads/issues.jsonl` as a fallback when SQLite (`beads.db`) is not available
- Maintains feature parity with the `bd` CLI which supports both storage backends
- SQLite is preferred when both files exist; JSONL is used only as fallback

## Changes

### New Files
- `src/bd/jsonl-parser.ts` - JSONL parsing logic with `loadBeadsFromJsonl()` function

### Modified Files
- `src/bd/parser.ts` - Add `getDataSource()` to detect available data source, delegate to appropriate loader
- `src/bd/watcher.ts` - Watch correct file (`beads.db` or `issues.jsonl`) based on data source
- `src/types.ts` - Add `DataSource`, `JsonlDependency`, `JsonlComment` types; extend `Issue` with optional JSONL fields
- `src/state/store.ts` - Add `dataSource` to initial state

### Bug Fixes (found during build)
- Fix Ink Box positioning properties in multiple components
- Fix `updateIssue()` call signature in CommandBar
- Fix store action names in DependencyGraph and TreeView
- Remove unsupported node-notifier properties

## Test plan

- [ ] Verify existing SQLite functionality unchanged
- [ ] Test with JSONL-only setup (remove beads.db, keep issues.jsonl)
- [ ] Test with both files present (should use SQLite)
- [ ] Test with neither file (should throw error)
- [ ] Verify file watcher monitors correct file