### PR TITLE
Fix DependencyGraph crash with sparse dependency levels

### DIFF
--- a/src/components/DependencyGraph.tsx
+++ b/src/components/DependencyGraph.tsx
@@ -28,7 +28,7 @@ function buildDependencyLevels(data: BeadsData): GraphNode[][] {
     if (processed.has(issue.id)) {
       // Already computed
       const found = levels.findIndex(level =>
-        level.some(node => node.issue.id === issue.id)
+        level && level.some(node => node.issue.id === issue.id)
       );
       return found >= 0 ? found : 0;
     }


### PR DESCRIPTION
## Summary

Fixes a `TypeError` crash in the Dependency Graph view (keyboard: `3`) that occurs when the dependency levels array is sparse.

## Problem

When viewing the dependency graph, the app would crash with:
```
TypeError: undefined is not an object (evaluating 'level.some')
```

This happened when issues had dependencies at non-consecutive levels (e.g., issues at level 0 and level 3, but none at levels 1-2), creating a sparse array with undefined elements.

## Solution

Added a null-safety check in the `getLevel()` function at `src/components/DependencyGraph.tsx:31`:

```typescript
const found = levels.findIndex(level =>
  level && level.some(node => node.issue.id === issue.id)
);
```

The `level &&` check safely skips undefined array elements during the search.

## Testing

- Tested with a project containing issues with sparse dependency levels
- Graph view now loads without crashing
- All dependency relationships display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)